### PR TITLE
Test Automation for Activities, Page Objects, Matchers, DI for Resources

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "com.frostrocket.doordash"
-        minSdkVersion 14
+        minSdkVersion 21
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"
@@ -21,9 +21,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
-        exclude group: 'com.android.support', module: 'support-annotations'
-    })
     compile 'com.android.support:appcompat-v7:25.1.1'
     compile 'com.android.support:design:25.1.1'
     compile 'com.google.android.gms:play-services-maps:10.0.1'
@@ -35,6 +32,27 @@ dependencies {
 
     compile 'com.jakewharton:butterknife:8.4.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.4.0'
+
+    compile 'com.google.dagger:dagger:2.11'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.11'
+
+    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
+    androidTestCompile('com.android.support.test.espresso:espresso-contrib:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-v4'
+        exclude group: 'com.android.support', module: 'appcompat-v7'
+        exclude group: 'com.android.support', module: 'design'
+        exclude group: 'com.android.support', module: 'support-annotations'
+        exclude group: 'com.android.support', module: 'recyclerview-v7'
+    })
+    androidTestCompile('com.android.support.test.espresso:espresso-intents:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    })
+    androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
+
+    androidTestCompile 'com.google.dagger:dagger:2.11'
+    androidTestAnnotationProcessor 'com.google.dagger:dagger-compiler:2.11'
 
     testCompile 'junit:junit:4.12'
 }

--- a/app/src/androidTest/java/com/frostrocket/doordash/activities/BaseRestaurantsTest.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/activities/BaseRestaurantsTest.java
@@ -1,0 +1,57 @@
+package com.frostrocket.doordash.activities;
+
+import android.support.test.espresso.ViewInteraction;
+
+import com.frostrocket.doordash.AppSharedPreferences;
+import com.frostrocket.doordash.R;
+import com.frostrocket.doordash.api.RestaurantClient;
+import com.frostrocket.doordash.api.model.Restaurant;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.assertThat;
+import static android.support.test.espresso.matcher.ViewMatchers.hasDescendant;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.frostrocket.doordash.matchers.CustomMatchers.withDrawable;
+import static org.hamcrest.core.Is.is;
+
+public abstract class BaseRestaurantsTest {
+
+    protected static final int DEFAULT_NUMBER = 5;
+
+    protected List<String> favoriteRestaurantIds;
+
+    protected void clearSharedPreferencesFavorites() {
+        List<String> favoriteRestaurantIds = AppSharedPreferences.getRestaurantIds();
+        for (String restaurantId : favoriteRestaurantIds) {
+            AppSharedPreferences.removeRestaurantId(Integer.valueOf(restaurantId));
+        }
+    }
+
+    protected void verifyRows(final Map<String, ViewInteraction> rows, final List<String> restaurantIds) throws Exception {
+        assertThat(rows.size(), is(restaurantIds.size()));
+
+        for (String restaurantId : restaurantIds) {
+            Restaurant restaurant = RestaurantClient.getRestaurant(restaurantId);
+            ViewInteraction row = rows.get(restaurantId);
+            row.check(matches(hasDescendant(withText(restaurant.getName()))));
+            row.check(matches(hasDescendant(withText(restaurant.getDescription()))));
+            verifyRowFavorite(row, restaurantId);
+        }
+    }
+
+    protected void verifyRowFavorite(final ViewInteraction row, final String restaurantId) {
+        if (favoriteRestaurantIds.indexOf(restaurantId) == -1) {
+            row.check(matches(hasDescendant(withDrawable(R.drawable.ic_heart_empty))));
+        } else {
+            row.check(matches(hasDescendant(withDrawable(R.drawable.ic_heart_filled))));
+        }
+    }
+
+    protected int getDefaultRandomNumber() {
+        return new Random().nextInt(DEFAULT_NUMBER);
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/activities/FavoritesActivityTest.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/activities/FavoritesActivityTest.java
@@ -1,0 +1,121 @@
+package com.frostrocket.doordash.activities;
+
+import android.content.Intent;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.RecyclerView;
+
+import com.frostrocket.doordash.AppSharedPreferences;
+import com.frostrocket.doordash.api.RestaurantClient;
+import com.frostrocket.doordash.api.model.Restaurant;
+import com.frostrocket.doordash.pages.FavoritesPage;
+import com.frostrocket.doordash.pages.ResultsPage;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static com.frostrocket.doordash.assertions.PageAssertion.assertAt;
+import static org.hamcrest.core.IsNot.not;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class FavoritesActivityTest extends BaseRestaurantsTest {
+
+    @Rule
+    public ActivityTestRule<FavoritesActivity> favoritesActivityRule = new ActivityTestRule(FavoritesActivity.class, true, false);
+    private List<String> originalFavoriteRestaurantIds;
+    private RecyclerView favoritesRecyclerView;
+    private FavoritesPage favoritesPage;
+
+    @Before
+    public void setUp() throws Exception {
+        clearSharedPreferencesFavorites();
+        retrieveRestaurantsAndAddToFavorites(5);
+        launchActivityWithIntent();
+        favoritesRecyclerView = favoritesActivityRule.getActivity().favoritesRecyclerView;
+        favoritesPage = new FavoritesPage();
+    }
+
+    @Test
+    public void loadComponents() {
+        // recycler view
+        favoritesPage.getRecyclerView().check(matches(isDisplayed()));
+
+        // loading spinner
+        favoritesPage.getLoadingSpinner().check(matches(not(isDisplayed())));
+    }
+
+    @Test
+    public void showFavorites() throws Exception {
+        verifyFavorites();
+    }
+
+    @Test
+    public void removeFavorites() throws Exception {
+        // given
+        List<String> idsToRemove = new ArrayList<>();
+        int numToRemove = getDefaultRandomNumber();
+        for (int i = 0; i < numToRemove; i++) {
+            String restaurantId = favoriteRestaurantIds.get(i);
+            if (!idsToRemove.contains(restaurantId)) {
+                idsToRemove.add(restaurantId);
+            }
+        }
+
+        // when
+        for (String idToRemove : idsToRemove) {
+            favoritesPage.clickFavorite(idToRemove, favoritesRecyclerView);
+            favoriteRestaurantIds.remove(idToRemove);
+        }
+
+        // then
+        verifyFavorites();
+    }
+
+    @Test
+    public void removeFavoriteThenAddBack() throws Exception {
+        // given
+        int index = getDefaultRandomNumber();
+        String restaurantId = favoriteRestaurantIds.get(index);
+        favoritesPage.clickFavorite(restaurantId, favoritesRecyclerView);
+
+        // when
+        favoritesPage.clickFavorite(restaurantId, favoritesRecyclerView);
+
+        // then
+        verifyFavorites();
+    }
+
+    private void retrieveRestaurantsAndAddToFavorites(int exclusiveIndex) throws IOException {
+        List<Restaurant> restaurants = RestaurantClient.getRestaurants(ResultsPage.DEFAULT_LATITUDE, ResultsPage.DEFAULT_LONGITUDE).subList(0, exclusiveIndex);
+        for (Restaurant restaurant : restaurants) {
+            AppSharedPreferences.addRestaurantId(restaurant.getId());
+        }
+        favoriteRestaurantIds = new ArrayList<>();
+        favoriteRestaurantIds.addAll(AppSharedPreferences.getRestaurantIds());
+        originalFavoriteRestaurantIds = new ArrayList<>();
+        originalFavoriteRestaurantIds.addAll(AppSharedPreferences.getRestaurantIds());
+    }
+
+    private void launchActivityWithIntent() {
+        Intent intent = new Intent();
+        favoritesActivityRule.launchActivity(intent);
+    }
+
+    private void verifyFavorites() throws Exception {
+        assertAt(FavoritesPage.class);
+        Map<String, ViewInteraction> rows = favoritesPage.getRows(originalFavoriteRestaurantIds, favoritesRecyclerView);
+        verifyRows(rows, originalFavoriteRestaurantIds);
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/activities/MainActivityIntentsTest.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/activities/MainActivityIntentsTest.java
@@ -1,0 +1,102 @@
+package com.frostrocket.doordash.activities;
+
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.idling.CountingIdlingResource;
+import android.support.test.espresso.intent.rule.IntentsTestRule;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.UiThreadTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.frostrocket.doordash.pages.MainPage;
+import com.frostrocket.doordash.pages.ResultsPage;
+import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.MapView;
+import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.MarkerOptions;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.intent.Intents.intended;
+import static android.support.test.espresso.intent.matcher.BundleMatchers.hasEntry;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.hasExtras;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.toPackage;
+import static org.hamcrest.core.AllOf.allOf;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class MainActivityIntentsTest {
+
+    @Rule
+    public IntentsTestRule<MainActivity> mainActivityRule = new IntentsTestRule<MainActivity>(MainActivity.class);
+    @Rule
+    public UiThreadTestRule threadTestRule = new UiThreadTestRule();
+    private CountingIdlingResource countingIdlingResource = new CountingIdlingResource("MapReady");
+    private GoogleMap googleMap;
+    private MainPage mainPage;
+
+    @Before
+    public void setUp() throws Throwable {
+        initMapViewWithIdlingResources();
+        mainPage = new MainPage();
+    }
+
+    @After
+    public void tearDown() {
+        // unregister counting idling resource
+        Espresso.unregisterIdlingResources(countingIdlingResource);
+    }
+
+    @Test
+    public void addNewMapMarker() throws Throwable {
+        // given
+        final Double[] latLong = new Double[2];
+        threadTestRule.runOnUiThread(new Runnable() {
+            @Override public void run() {
+                googleMap.clear();
+                googleMap.addMarker(new MarkerOptions().position(new LatLng(ResultsPage.DEFAULT_LATITUDE, ResultsPage.DEFAULT_LONGITUDE)));
+                latLong[0] = googleMap.getCameraPosition().target.latitude;
+                latLong[1] = googleMap.getCameraPosition().target.longitude;
+            }
+        });
+
+        // when
+        mainPage.clickSearchButton();
+
+        // then
+        intended(allOf(
+                toPackage("com.frostrocket.doordash"),
+                hasExtras(allOf(
+                        hasEntry(equalTo(ResultsPage.LATITUDE_KEY), equalTo(latLong[0])),
+                        hasEntry(equalTo(ResultsPage.LONGITUDE_KEY), equalTo(latLong[1]))
+                ))
+        ));
+    }
+
+    private void initMapViewWithIdlingResources() throws Throwable {
+        // setup counting idling resource on map ready callback
+        countingIdlingResource.increment();
+        final MapView mapView = mainActivityRule.getActivity().mapView;
+        final OnMapReadyCallback onMapReadyCallback = new OnMapReadyCallback() {
+            @Override public void onMapReady(GoogleMap googleMap) {
+                countingIdlingResource.decrement();
+                MainActivityIntentsTest.this.googleMap = googleMap;
+            }
+        };
+
+        // run get map async on map view
+        threadTestRule.runOnUiThread(new Runnable() {
+            @Override public void run() {
+                mapView.getMapAsync(onMapReadyCallback);
+            }
+        });
+
+        // register counting idling resource
+        Espresso.registerIdlingResources(countingIdlingResource);
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/activities/MainActivityTest.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/activities/MainActivityTest.java
@@ -1,0 +1,69 @@
+package com.frostrocket.doordash.activities;
+
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.frostrocket.doordash.pages.FavoritesPage;
+import com.frostrocket.doordash.pages.MainPage;
+import com.frostrocket.doordash.pages.ResultsPage;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static com.frostrocket.doordash.assertions.PageAssertion.assertAt;
+import static org.hamcrest.core.IsNot.not;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class MainActivityTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> mainActivityRule = new ActivityTestRule(MainActivity.class);
+    private MainPage mainPage;
+
+    @Before
+    public void setUp() {
+        mainPage = new MainPage();
+    }
+
+    @Test
+    public void loadComponents() {
+        // toolbar
+        mainPage.getToolbar().check(matches(isDisplayed()));
+
+        // favorites menu option
+        mainPage.getFavoritesMenuOption().check(matches(isDisplayed()));
+
+        // map view
+        mainPage.getMapView().check(matches(isDisplayed()));
+
+        // map marker
+        mainPage.getMapMarker().check(matches(not(isDisplayed())));
+
+        // search button
+        mainPage.getSearchButton().check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void clickFavoritesMenuOption() throws Exception {
+        // click favorites menu option
+        mainPage.clickFavoritesMenuOption();
+
+        // assert at favorites page
+        assertAt(FavoritesPage.class);
+    }
+
+    @Test
+    public void clickSearchButton() throws Exception {
+        // click search button
+        mainPage.clickSearchButton();
+
+        // assert at results page
+        assertAt(ResultsPage.class);
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/activities/ResultsActivityTest.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/activities/ResultsActivityTest.java
@@ -1,0 +1,167 @@
+package com.frostrocket.doordash.activities;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.idling.CountingIdlingResource;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.support.v7.widget.RecyclerView;
+
+import com.frostrocket.doordash.DoorDash;
+import com.frostrocket.doordash.api.RestaurantClient;
+import com.frostrocket.doordash.api.model.Restaurant;
+import com.frostrocket.doordash.dagger.DaggerResultsComponent;
+import com.frostrocket.doordash.dagger.TestRestaurantsWorkerModule;
+import com.frostrocket.doordash.pages.ResultsPage;
+import com.frostrocket.doordash.workers.TestRestaurantsWorker;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static com.frostrocket.doordash.assertions.PageAssertion.assertAt;
+import static org.hamcrest.core.IsNot.not;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class ResultsActivityTest extends BaseRestaurantsTest {
+
+    @Rule
+    public ActivityTestRule<ResultsActivity> resultsActivityRule = new ActivityTestRule(ResultsActivity.class, true, false);
+    private double latitude = ResultsPage.DEFAULT_LATITUDE;
+    private double longitude = ResultsPage.DEFAULT_LONGITUDE;
+    private List<String> favoriteRestaurantIds = new ArrayList<>();
+    private List<String> resultRestaurantIds;
+    private DoorDash doorDash;
+    private CountingIdlingResource countingIdlingResource;
+    private RecyclerView resultsRecyclerView;
+    private ResultsPage resultsPage;
+
+    @Before
+    public void setUp() throws Exception {
+        injectTestModulesToApp();
+        clearSharedPreferencesFavorites();
+        retrieveRestaurantsAndAddToResults();
+        launchActivityWithIntent();
+        initRestaurantsWorkerWithIdlingResources();
+        resultsRecyclerView = resultsActivityRule.getActivity().resultsRecyclerView;
+        resultsPage = new ResultsPage();
+    }
+
+    @After
+    public void tearDown() {
+        // unregister counting idling resource
+        Espresso.unregisterIdlingResources(countingIdlingResource);
+    }
+
+    @Test
+    public void loadComponents() {
+        // recycler view
+        resultsPage.getRecyclerView().check(matches(isDisplayed()));
+
+        // loading spinner
+        resultsPage.getLoadingSpinner().check(matches(not(isDisplayed())));
+    }
+
+    @Test
+    public void showResults() throws Exception {
+        verifyResults();
+    }
+
+    @Test
+    public void addFavorites() throws Exception {
+        // given
+        List<String> idsToAdd = new ArrayList<>();
+        int numToAdd = getDefaultRandomNumber();
+        for (int i = 0; i < numToAdd; i++) {
+            int index = getDefaultRandomNumber();
+            String restaurantId = resultRestaurantIds.get(index);
+            if (!idsToAdd.contains(restaurantId)) {
+                idsToAdd.add(restaurantId);
+            }
+        }
+
+        // when
+        for (String idToAdd : idsToAdd) {
+            resultsPage.clickFavorite(idToAdd, resultsRecyclerView);
+            favoriteRestaurantIds.add(idToAdd);
+        }
+
+        // then
+        verifyResults();
+    }
+
+    public void addFavoriteThenRemoveOut() throws Exception {
+        // given
+        int index = getDefaultRandomNumber();
+        String restaurantId = resultRestaurantIds.get(index);
+        resultsPage.clickFavorite(restaurantId, resultsRecyclerView);
+
+        // when
+        resultsPage.clickFavorite(restaurantId, resultsRecyclerView);
+
+        // then
+        verifyResults();
+    }
+
+    @Test
+    public void removeFavorite() throws Exception {
+        // given
+        int index = getDefaultRandomNumber();
+        String restaurantId = resultRestaurantIds.get(index);
+        resultsPage.clickFavorite(restaurantId, resultsRecyclerView);
+
+        // when
+        resultsPage.clickFavorite(restaurantId, resultsRecyclerView);
+
+        // then
+        verifyResults();
+    }
+
+    private void injectTestModulesToApp() {
+        doorDash = (DoorDash) InstrumentationRegistry.getTargetContext().getApplicationContext();
+        DaggerResultsComponent.builder().restaurantsWorkerModule(new TestRestaurantsWorkerModule()).build().inject(doorDash);
+    }
+
+    private void retrieveRestaurantsAndAddToResults() throws IOException {
+        List<Restaurant> restaurants = RestaurantClient.getRestaurants(latitude, longitude);
+        resultRestaurantIds = new ArrayList<>();
+        for (Restaurant restaurant : restaurants) {
+            resultRestaurantIds.add(restaurant.getId().toString());
+        }
+    }
+
+    private void launchActivityWithIntent() {
+        Intent intent = new Intent();
+        intent.putExtra(ResultsPage.LATITUDE_KEY, latitude);
+        intent.putExtra(ResultsPage.LONGITUDE_KEY, longitude);
+        resultsActivityRule.launchActivity(intent);
+    }
+
+    private void initRestaurantsWorkerWithIdlingResources() {
+        // set idling resource
+        countingIdlingResource = ((TestRestaurantsWorker) doorDash.getRestaurantsWorker()).getCountingIdlingResource();
+        assert null != countingIdlingResource;
+
+        // register counting idling resource
+        Espresso.registerIdlingResources(countingIdlingResource);
+    }
+
+    private void verifyResults() throws Exception {
+        assertAt(ResultsPage.class);
+        Map<String, ViewInteraction> rows = resultsPage.getRows(resultRestaurantIds, resultsRecyclerView);
+        verifyRows(rows, resultRestaurantIds);
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/api/RestaurantClient.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/api/RestaurantClient.java
@@ -1,0 +1,17 @@
+package com.frostrocket.doordash.api;
+
+import com.frostrocket.doordash.api.model.Restaurant;
+
+import java.io.IOException;
+import java.util.List;
+
+public class RestaurantClient {
+
+    public static Restaurant getRestaurant(final String restaurantId) throws IOException {
+        return RestClient.getInstance().getRestaurant(Integer.valueOf(restaurantId));
+    }
+
+    public static List<Restaurant> getRestaurants(final double latitude, final double longitude) throws IOException {
+        return RestClient.getInstance().getRestaurants(latitude, longitude);
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/assertions/PageAssertion.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/assertions/PageAssertion.java
@@ -1,0 +1,10 @@
+package com.frostrocket.doordash.assertions;
+
+import com.frostrocket.doordash.pages.BasePage;
+
+public class PageAssertion {
+
+    public static void assertAt(Class pageClass) throws Exception {
+        pageClass.asSubclass(BasePage.class).getConstructors()[0].newInstance();
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/dagger/TestRestaurantsWorkerModule.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/dagger/TestRestaurantsWorkerModule.java
@@ -1,0 +1,12 @@
+package com.frostrocket.doordash.dagger;
+
+import com.frostrocket.doordash.workers.RestaurantsWorker;
+import com.frostrocket.doordash.workers.TestRestaurantsWorker;
+
+public class TestRestaurantsWorkerModule extends RestaurantsWorkerModule {
+
+    @Override
+    RestaurantsWorker provideRestaurantsWorker() {
+        return new TestRestaurantsWorker();
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/matchers/CustomMatchers.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/matchers/CustomMatchers.java
@@ -1,0 +1,16 @@
+package com.frostrocket.doordash.matchers;
+
+public class CustomMatchers {
+
+    public static DrawableMatcher withDrawable(final int resourceId) {
+        return new DrawableMatcher(resourceId);
+    }
+
+    public static DrawableMatcher noDrawable() {
+        return new DrawableMatcher(-1);
+    }
+
+    public static RecyclerViewMatcher withRecyclerView(final int recyclerViewId) {
+        return new RecyclerViewMatcher(recyclerViewId);
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/matchers/DrawableMatcher.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/matchers/DrawableMatcher.java
@@ -1,0 +1,67 @@
+package com.frostrocket.doordash.matchers;
+
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.view.View;
+import android.widget.ImageView;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Modified and improved version.
+ *
+ * Source: https://medium.com/@dbottillo/android-ui-test-espresso-matcher-for-imageview-1a28c832626f
+ */
+public class DrawableMatcher extends TypeSafeMatcher<View> {
+
+    private final int drawableId;
+    private Resources resources;
+
+    public DrawableMatcher(int drawableId) {
+        super(View.class);
+        this.drawableId = drawableId;
+    }
+
+    @Override
+    protected boolean matchesSafely(View view) {
+        if (!(view instanceof ImageView)) {
+            return false;
+        }
+
+        ImageView imageView = (ImageView) view;
+        if (drawableId < 0) {
+            return null == imageView.getDrawable();
+        }
+
+        resources = view.getResources();
+        if (null == resources) {
+            return false;
+        }
+
+        Drawable drawable = resources.getDrawable(drawableId, null);
+        if (null == drawable) {
+            return false;
+        }
+
+        Bitmap bitmap = ((BitmapDrawable) imageView.getDrawable()).getBitmap();
+        Bitmap otherBitmap = ((BitmapDrawable) drawable).getBitmap();
+        return bitmap.sameAs(otherBitmap);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        String resourceName = Integer.toString(drawableId);
+        if (null != resources) {
+            try {
+                resourceName = resources.getResourceName(drawableId);
+            } catch (Resources.NotFoundException ex) {
+                resourceName = String.format("%s (resource name not found)", drawableId);
+            }
+        }
+
+        description.appendText("Drawable with id: " + resourceName);
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/matchers/RecyclerViewMatcher.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/matchers/RecyclerViewMatcher.java
@@ -1,0 +1,76 @@
+package com.frostrocket.doordash.matchers;
+
+import android.content.res.Resources;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Modified and improved version.
+ *
+ * Source: https://spin.atomicobject.com/2016/04/15/espresso-testing-recyclerviews/
+ * Fork of the RecyclerViewMatcher from https://github.com/dannyroa/espresso-samples
+ * License: MIT (https://tldrlegal.com/license/mit-license)
+ */
+public class RecyclerViewMatcher {
+
+    private final int recyclerViewId;
+
+    public RecyclerViewMatcher(final int recyclerViewId) {
+        this.recyclerViewId = recyclerViewId;
+    }
+
+    public Matcher<View> atPosition(final int position) {
+        return atPositionOnView(position, -1);
+    }
+
+    public Matcher<View> atPositionOnView(final int position, final int targetViewId) {
+        return new TypeSafeMatcher<View>() {
+            Resources resources;
+            View itemView;
+
+            @Override
+            public boolean matchesSafely(View view) {
+                resources = view.getResources();
+
+                RecyclerView recyclerView = (RecyclerView) view.getRootView().findViewById(recyclerViewId);
+                if (null == recyclerView || recyclerViewId != recyclerView.getId()) {
+                    return false;
+                }
+
+                RecyclerView.ViewHolder viewHolder = recyclerView.findViewHolderForAdapterPosition(position);
+                if (null == itemView && null != viewHolder) {
+                    itemView = viewHolder.itemView;
+                }
+
+                if (targetViewId == -1) {
+                    return view == itemView;
+                }
+
+                if (null == itemView) {
+                    return false;
+                }
+
+                View targetView = itemView.findViewById(targetViewId);
+                return view == targetView;
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                String resourceName = Integer.toString(recyclerViewId);
+                if (null != resources) {
+                    try {
+                        resourceName = resources.getResourceName(recyclerViewId);
+                    } catch (Resources.NotFoundException ex) {
+                        resourceName = String.format("%s (resource name not found)", recyclerViewId);
+                    }
+                }
+
+                description.appendText("RecyclerView with id: " + resourceName + " at position: " + position);
+            }
+        };
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/pages/BasePage.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/pages/BasePage.java
@@ -1,0 +1,10 @@
+package com.frostrocket.doordash.pages;
+
+public abstract class BasePage {
+
+    protected BasePage() {
+        verifyAtPage();
+    }
+
+    protected abstract void verifyAtPage();
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/pages/BaseRestaurantsPage.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/pages/BaseRestaurantsPage.java
@@ -1,0 +1,85 @@
+package com.frostrocket.doordash.pages;
+
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.contrib.RecyclerViewActions;
+import android.support.v7.widget.RecyclerView;
+
+import com.frostrocket.doordash.R;
+import com.frostrocket.doordash.adapters.RestaurantsAdapter;
+import com.frostrocket.doordash.api.model.Restaurant;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.hasSibling;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.frostrocket.doordash.matchers.CustomMatchers.withRecyclerView;
+import static org.hamcrest.core.AllOf.allOf;
+
+public abstract class BaseRestaurantsPage extends BasePage implements RestaurantsPage {
+
+    @Override
+    public ViewInteraction getRecyclerView() {
+        return onView(withId(getRecyclerViewId()));
+    }
+
+    @Override
+    public ViewInteraction getLoadingSpinner() {
+        return new ProgressBarPage().getLoadingSpinner();
+    }
+
+    @Override
+    public int getAdapterPosition(final String restaurantId, final RecyclerView recyclerView) throws IOException {
+        List<Restaurant> restaurants = getRestaurantsFromAdapter(recyclerView);
+        Restaurant restaurant = getRestaurantFromList(restaurantId, restaurants);
+        return restaurants.indexOf(restaurant);
+    }
+
+    @Override
+    public ViewInteraction getRow(final int adapterPosition) throws IOException {
+        scrollToPosition(adapterPosition);
+        return onView(withRecyclerView(getRecyclerViewId()).atPosition(adapterPosition));
+    }
+
+    @Override
+    public Map<String, ViewInteraction> getRows(final List<String> restaurantIds, final RecyclerView recyclerView) throws IOException {
+        Map<String, ViewInteraction> rows = new HashMap<>();
+        for (String restaurantId : restaurantIds) {
+            int adapterPosition = getAdapterPosition(restaurantId, recyclerView);
+            rows.put(restaurantId, getRow(adapterPosition));
+        }
+        return rows;
+    }
+
+    @Override
+    public void clickFavorite(final String restaurantId, final RecyclerView recyclerView) throws IOException {
+        int adapterPosition = getAdapterPosition(restaurantId, recyclerView);
+        scrollToPosition(adapterPosition);
+        List<Restaurant> restaurants = getRestaurantsFromAdapter(recyclerView);
+        Restaurant restaurant = getRestaurantFromList(restaurantId, restaurants);
+        onView(allOf(withId(R.id.image_restaurant_favorite), hasSibling(withText(restaurant.getName())))).perform(click());
+    }
+
+    private Restaurant getRestaurantFromList(String restaurantId, List<Restaurant> restaurants) {
+        for (Restaurant actualRestaurant : restaurants) {
+            if (restaurantId.equals(actualRestaurant.getId().toString())) {
+                return actualRestaurant;
+            }
+        }
+        throw new IllegalArgumentException("Restaurant id: " + restaurantId + " does not exist, restaurants size: " + restaurants.size());
+    }
+
+    private List<Restaurant> getRestaurantsFromAdapter(RecyclerView recyclerView) {
+        RestaurantsAdapter restaurantsAdapter = (RestaurantsAdapter) recyclerView.getAdapter();
+        return restaurantsAdapter.getRestaurants();
+    }
+
+    private void scrollToPosition(int adapterPosition) {
+        onView(withId(getRecyclerViewId())).perform(RecyclerViewActions.scrollToPosition(adapterPosition));
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/pages/FavoritesPage.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/pages/FavoritesPage.java
@@ -1,0 +1,19 @@
+package com.frostrocket.doordash.pages;
+
+import com.frostrocket.doordash.R;
+
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+
+public class FavoritesPage extends BaseRestaurantsPage {
+
+    @Override
+    protected void verifyAtPage() {
+        getRecyclerView().check(matches(isDisplayed()));
+    }
+
+    @Override
+    public int getRecyclerViewId() {
+        return R.id.recycler_view_favorites;
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/pages/MainMenuPage.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/pages/MainMenuPage.java
@@ -1,0 +1,27 @@
+package com.frostrocket.doordash.pages;
+
+import android.support.test.espresso.ViewInteraction;
+
+import com.frostrocket.doordash.R;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+public class MainMenuPage extends BasePage {
+
+    @Override
+    protected void verifyAtPage() {
+        getFavoritesMenuOption().check(matches(isDisplayed()));
+    }
+
+    public ViewInteraction getFavoritesMenuOption() {
+        return onView(withId(R.id.action_show_favorites));
+    }
+
+    public void clickFavoritesMenuOption() {
+        getFavoritesMenuOption().perform(click());
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/pages/MainPage.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/pages/MainPage.java
@@ -1,0 +1,50 @@
+package com.frostrocket.doordash.pages;
+
+import android.support.test.espresso.ViewInteraction;
+
+import com.frostrocket.doordash.R;
+import com.frostrocket.doordash.utils.PermissionGranter;
+
+import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+public class MainPage extends BasePage {
+
+    @Override
+    protected void verifyAtPage() {
+        PermissionGranter.allowPermissionsIfNeeded(ACCESS_FINE_LOCATION);
+        getMapView().check(matches(isDisplayed()));
+    }
+
+    public ViewInteraction getToolbar() {
+        return onView(withId(R.id.toolbar));
+    }
+
+    public ViewInteraction getFavoritesMenuOption() {
+        return new MainMenuPage().getFavoritesMenuOption();
+    }
+
+    public ViewInteraction getMapView() {
+        return onView(withId(R.id.map_view));
+    }
+
+    public ViewInteraction getMapMarker() {
+        return onView(withId(R.id.map_marker));
+    }
+
+    public ViewInteraction getSearchButton() {
+        return onView(withId(R.id.fab));
+    }
+
+    public void clickFavoritesMenuOption() {
+        new MainMenuPage().clickFavoritesMenuOption();
+    }
+
+    public void clickSearchButton() {
+        getSearchButton().perform(click());
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/pages/ProgressBarPage.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/pages/ProgressBarPage.java
@@ -1,0 +1,20 @@
+package com.frostrocket.doordash.pages;
+
+import android.support.test.espresso.ViewInteraction;
+
+import com.frostrocket.doordash.R;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+public class ProgressBarPage extends BasePage {
+
+    @Override
+    protected void verifyAtPage() {
+        // do nothing
+    }
+
+    public ViewInteraction getLoadingSpinner() {
+        return onView(withId(R.id.loading_spinner));
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/pages/RestaurantsPage.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/pages/RestaurantsPage.java
@@ -1,0 +1,25 @@
+package com.frostrocket.doordash.pages;
+
+import android.support.test.espresso.ViewInteraction;
+import android.support.v7.widget.RecyclerView;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public interface RestaurantsPage {
+
+    int getRecyclerViewId();
+
+    ViewInteraction getRecyclerView();
+
+    ViewInteraction getLoadingSpinner();
+
+    int getAdapterPosition(final String restaurantId, final RecyclerView recyclerView) throws IOException;
+
+    ViewInteraction getRow(final int adapterPosition) throws IOException;
+
+    Map<String, ViewInteraction> getRows(final List<String> restaurantIds, final RecyclerView recyclerView) throws IOException;
+
+    void clickFavorite(final String restaurantId, final RecyclerView recyclerView) throws IOException;
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/pages/ResultsPage.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/pages/ResultsPage.java
@@ -1,0 +1,24 @@
+package com.frostrocket.doordash.pages;
+
+import com.frostrocket.doordash.R;
+
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+
+public class ResultsPage extends BaseRestaurantsPage {
+
+    public static final String LATITUDE_KEY = "LATITUDE";
+    public static final String LONGITUDE_KEY = "LONGITUDE";
+    public static final double DEFAULT_LATITUDE = 37.422740;
+    public static final double DEFAULT_LONGITUDE = -122.139956;
+
+    @Override
+    protected void verifyAtPage() {
+        getRecyclerView().check(matches(isDisplayed()));
+    }
+
+    @Override
+    public int getRecyclerViewId() {
+        return R.id.recycler_view_results;
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/utils/PermissionGranter.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/utils/PermissionGranter.java
@@ -1,0 +1,47 @@
+package com.frostrocket.doordash.utils;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.uiautomator.UiDevice;
+import android.support.test.uiautomator.UiObject;
+import android.support.test.uiautomator.UiObjectNotFoundException;
+import android.support.test.uiautomator.UiSelector;
+import android.support.v4.content.ContextCompat;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+
+/**
+ * Modified and improved version.
+ *
+ * Source: https://stackoverflow.com/questions/33929937/android-marshmallow-test-permissions-with-espresso
+ */
+public class PermissionGranter {
+
+    private static final int PERMISSIONS_DIALOG_DELAY = 3000;
+    private static final int GRANT_BUTTON_INDEX = 1;
+
+    public static void allowPermissionsIfNeeded(final String permissionName) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !hasNeededPermission(permissionName)) {
+                UiDevice device = UiDevice.getInstance(getInstrumentation());
+                UiObject allowPermissions = device.findObject(new UiSelector()
+                        .clickable(true)
+                        .checkable(false)
+                        .index(GRANT_BUTTON_INDEX));
+                if (allowPermissions.waitForExists(PERMISSIONS_DIALOG_DELAY)) {
+                    allowPermissions.click();
+                }
+            }
+        } catch (UiObjectNotFoundException e) {
+            System.out.println("There is no permissions dialog to interact with");
+        }
+    }
+
+    private static boolean hasNeededPermission(String permissionNeeded) {
+        Context context = InstrumentationRegistry.getTargetContext();
+        int permissionStatus = ContextCompat.checkSelfPermission(context, permissionNeeded);
+        return PackageManager.PERMISSION_GRANTED == permissionStatus;
+    }
+}

--- a/app/src/androidTest/java/com/frostrocket/doordash/workers/TestRestaurantsWorker.java
+++ b/app/src/androidTest/java/com/frostrocket/doordash/workers/TestRestaurantsWorker.java
@@ -1,0 +1,64 @@
+package com.frostrocket.doordash.workers;
+
+import android.support.test.espresso.idling.CountingIdlingResource;
+import android.view.View;
+import android.widget.ProgressBar;
+
+import com.frostrocket.doordash.adapters.RestaurantsAdapter;
+import com.frostrocket.doordash.api.RestClient;
+import com.frostrocket.doordash.api.model.Restaurant;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import rx.Single;
+import rx.SingleSubscriber;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
+import timber.log.Timber;
+
+public class TestRestaurantsWorker implements RestaurantsWorker {
+
+    private CountingIdlingResource countingIdlingResource;
+
+    public TestRestaurantsWorker() {
+        countingIdlingResource = new CountingIdlingResource("ResultsReady");
+    }
+
+    @Override
+    public void retrieveAndSetRestaurants(final double latitude, final double longitude, final RestaurantsAdapter restaurantsAdapter, final ProgressBar progressBar) {
+        Single<List<Restaurant>> restaurantSingle = Single.fromCallable(new Callable<List<Restaurant>>() {
+            @Override
+            public List<Restaurant> call() throws Exception {
+                progressBar.setVisibility(View.VISIBLE);
+
+                return RestClient.getInstance().getRestaurants(latitude, longitude);
+            }
+        });
+
+        countingIdlingResource.increment();
+        restaurantSingle.subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe(new SingleSubscriber<List<Restaurant>>() {
+            @Override
+            public void onSuccess(List<Restaurant> restaurants) {
+                progressBar.setVisibility(View.INVISIBLE);
+
+                for(Restaurant restaurant : restaurants) {
+                    restaurantsAdapter.add(restaurant);
+                }
+
+                countingIdlingResource.decrement();
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                Timber.e(error.toString());
+
+                countingIdlingResource.decrement();
+            }
+        });
+    }
+
+    public CountingIdlingResource getCountingIdlingResource() {
+        return countingIdlingResource;
+    }
+}

--- a/app/src/main/java/com/frostrocket/doordash/DoorDash.java
+++ b/app/src/main/java/com/frostrocket/doordash/DoorDash.java
@@ -4,11 +4,20 @@ import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import com.frostrocket.doordash.dagger.DaggerResultsComponent;
+import com.frostrocket.doordash.dagger.RestaurantsWorkerModule;
+import com.frostrocket.doordash.workers.RestaurantsWorker;
+
+import javax.inject.Inject;
+
 import timber.log.Timber;
 
 public class DoorDash extends Application {
     private static DoorDash instance;
     private static Context context;
+
+    @Inject
+    RestaurantsWorker restaurantsWorker;
 
     @Override
     public void onCreate() {
@@ -20,6 +29,14 @@ public class DoorDash extends Application {
         if (BuildConfig.DEBUG) {
             Timber.plant(new Timber.DebugTree());
         }
+
+        DaggerResultsComponent.builder().restaurantsWorkerModule(new RestaurantsWorkerModule()).build().inject(this);
+
+        assert null != restaurantsWorker;
+    }
+
+    public RestaurantsWorker getRestaurantsWorker() {
+        return restaurantsWorker;
     }
 
     public static synchronized DoorDash getInstance() {

--- a/app/src/main/java/com/frostrocket/doordash/adapters/RestaurantsAdapter.java
+++ b/app/src/main/java/com/frostrocket/doordash/adapters/RestaurantsAdapter.java
@@ -14,6 +14,7 @@ import com.frostrocket.doordash.api.model.Restaurant;
 import com.frostrocket.doordash.AppSharedPreferences;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import butterknife.BindView;
@@ -79,6 +80,10 @@ public class RestaurantsAdapter extends RecyclerView.Adapter<RestaurantsAdapter.
     @Override
     public int getItemCount() {
         return restaurants.size();
+    }
+
+    public List<Restaurant> getRestaurants() {
+        return Collections.unmodifiableList(restaurants);
     }
 
     public void add(Restaurant restaurant) {

--- a/app/src/main/java/com/frostrocket/doordash/dagger/RestaurantsWorkerModule.java
+++ b/app/src/main/java/com/frostrocket/doordash/dagger/RestaurantsWorkerModule.java
@@ -1,0 +1,16 @@
+package com.frostrocket.doordash.dagger;
+
+import com.frostrocket.doordash.workers.DefaultRestaurantsWorker;
+import com.frostrocket.doordash.workers.RestaurantsWorker;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class RestaurantsWorkerModule {
+
+    @Provides
+    RestaurantsWorker provideRestaurantsWorker() {
+        return new DefaultRestaurantsWorker();
+    }
+}

--- a/app/src/main/java/com/frostrocket/doordash/dagger/ResultsComponent.java
+++ b/app/src/main/java/com/frostrocket/doordash/dagger/ResultsComponent.java
@@ -1,0 +1,16 @@
+package com.frostrocket.doordash.dagger;
+
+import com.frostrocket.doordash.DoorDash;
+
+import javax.inject.Singleton;
+
+import dagger.Component;
+
+@Singleton
+@Component(modules = {
+        RestaurantsWorkerModule.class
+})
+public interface ResultsComponent {
+
+    void inject(DoorDash doorDash);
+}

--- a/app/src/main/java/com/frostrocket/doordash/workers/DefaultRestaurantsWorker.java
+++ b/app/src/main/java/com/frostrocket/doordash/workers/DefaultRestaurantsWorker.java
@@ -1,0 +1,48 @@
+package com.frostrocket.doordash.workers;
+
+import android.view.View;
+import android.widget.ProgressBar;
+
+import com.frostrocket.doordash.adapters.RestaurantsAdapter;
+import com.frostrocket.doordash.api.RestClient;
+import com.frostrocket.doordash.api.model.Restaurant;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import rx.Single;
+import rx.SingleSubscriber;
+import rx.android.schedulers.AndroidSchedulers;
+import rx.schedulers.Schedulers;
+import timber.log.Timber;
+
+public class DefaultRestaurantsWorker implements RestaurantsWorker {
+
+    @Override
+    public void retrieveAndSetRestaurants(final double latitude, final double longitude, final RestaurantsAdapter restaurantsAdapter, final ProgressBar progressBar) {
+        Single<List<Restaurant>> restaurantSingle = Single.fromCallable(new Callable<List<Restaurant>>() {
+            @Override
+            public List<Restaurant> call() throws Exception {
+                progressBar.setVisibility(View.VISIBLE);
+
+                return RestClient.getInstance().getRestaurants(latitude, longitude);
+            }
+        });
+
+        restaurantSingle.subscribeOn(Schedulers.io()).observeOn(AndroidSchedulers.mainThread()).subscribe(new SingleSubscriber<List<Restaurant>>() {
+            @Override
+            public void onSuccess(List<Restaurant> restaurants) {
+                progressBar.setVisibility(View.INVISIBLE);
+
+                for(Restaurant restaurant : restaurants) {
+                    restaurantsAdapter.add(restaurant);
+                }
+            }
+
+            @Override
+            public void onError(Throwable error) {
+                Timber.e(error.toString());
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/frostrocket/doordash/workers/RestaurantsWorker.java
+++ b/app/src/main/java/com/frostrocket/doordash/workers/RestaurantsWorker.java
@@ -1,0 +1,10 @@
+package com.frostrocket.doordash.workers;
+
+import android.widget.ProgressBar;
+
+import com.frostrocket.doordash.adapters.RestaurantsAdapter;
+
+public interface RestaurantsWorker {
+
+    void retrieveAndSetRestaurants(final double latitude, final double longitude, final RestaurantsAdapter restaurantsAdapter, final ProgressBar progressBar);
+}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Wed Jun 07 18:09:34 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
Goal: To create automated tests against the DoorDash app, particularly the activities.
- created page objects
- added improved view matchers and assertions (sources indicated in the classes)
- added dependency injenction for async workers using dagger 2
- refactored ResultsActivity and pulled out a DefaultRestaurantsWorker and a TestRestaurantsWorker (in order to apply idling resource on test)
- added util for permission granting
- created ui and intent tests using espresso and ui automator
- added necessary libraries to the gradle build

Points to improve:
- create more distinct dagger components as opposed to just distinct dagger modules
- add more edge case tests, unit tests on non-activity classes, api client tests, end-to-end appium tests
- pull requests could have been done in phases
- java docs

To run tests:
- open in Android Studio and run espresso tests
- make sure to either have virtual or physical device